### PR TITLE
more comprehensive support for IAM role authentication

### DIFF
--- a/src/main/java/org/craftercms/deployer/aws/utils/AwsConfig.java
+++ b/src/main/java/org/craftercms/deployer/aws/utils/AwsConfig.java
@@ -18,6 +18,8 @@
 package org.craftercms.deployer.aws.utils;
 
 import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.lang.StringUtils;
+
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -44,7 +46,7 @@ public abstract class AwsConfig {
     }
 
     public static AWSCredentialsProvider getCredentials(final Configuration config) {
-        if(config.containsKey(ACCESS_KEY_CONFIG_KEY)) {
+        if(StringUtils.isNotBlank(config.getString(ACCESS_KEY_CONFIG_KEY))) {
             return new AWSStaticCredentialsProvider(new BasicAWSCredentials(config.getString(ACCESS_KEY_CONFIG_KEY),
                 config.getString(SECRET_KEY_CONFIG_KEY)));
         } else {


### PR DESCRIPTION
This change ensures that an expired key scenario would not occur from a role based credentials provider by creating a dynamo connection only during the doExecute of the deployer. Additionally, there is an updated check for empty key configuration values before using access & secret keys