### PR TITLE
Termination checkpoint

### DIFF
--- a/src/main/java/org/craftercms/deployer/aws/kinesis/AbstractKinesisRecordProcessor.java
+++ b/src/main/java/org/craftercms/deployer/aws/kinesis/AbstractKinesisRecordProcessor.java
@@ -86,9 +86,8 @@ public abstract class AbstractKinesisRecordProcessor implements IRecordProcessor
         logger.info("Shutting down");
         if (!failed && shutdownInput.getShutdownReason() == ShutdownReason.TERMINATE) {
             try {
-                shutdownInput.getCheckpointer().checkpoint();
-            }
-            catch (Exception e) {
+                checkpoint(shutdownInput.getCheckpointer());
+            } catch (Exception e) {
                 logger.error("Error shutting down", e);
             }
         }

--- a/src/main/java/org/craftercms/deployer/aws/utils/SearchHelper.java
+++ b/src/main/java/org/craftercms/deployer/aws/utils/SearchHelper.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.craftercms.search.service.SearchService;
+import org.craftercms.search.exception.SearchException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.amazonaws.services.dynamodbv2.document.ItemUtils;
@@ -79,7 +80,11 @@ public class SearchHelper {
         }
         logger.debug("Indexing doc with id '{}'", id);
         String xml = xmlMapper.writeValueAsString(map);
-        searchService.update(siteName, siteName, id, xml, true);
+        try {
+            searchService.update(siteName, siteName, id, xml, true);
+        } catch (SearchException e) {
+            logger.error("Failed to index doc into search index!", e);
+        }
     }
 
     /**

--- a/src/main/java/org/craftercms/deployer/aws/utils/SearchHelper.java
+++ b/src/main/java/org/craftercms/deployer/aws/utils/SearchHelper.java
@@ -21,7 +21,6 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.craftercms.search.service.SearchService;
-import org.craftercms.search.exception.SearchException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.amazonaws.services.dynamodbv2.document.ItemUtils;
@@ -80,11 +79,7 @@ public class SearchHelper {
         }
         logger.debug("Indexing doc with id '{}'", id);
         String xml = xmlMapper.writeValueAsString(map);
-        try {
-            searchService.update(siteName, siteName, id, xml, true);
-        } catch (SearchException e) {
-            logger.error("Failed to index doc into search index!", e);
-        }
+        searchService.update(siteName, siteName, id, xml, true);
     }
 
     /**


### PR DESCRIPTION
Invoke the AbstractKinesisRecordProcessor's own checkpoint override when checkpoint-ing during termination to see further root cause details for when checkpoint creation fails and to have better handling for any throttling issues.